### PR TITLE
change site meta-description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="A mathematically optimal trajectory generator for FRC"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
"A mathematically optimal trajectory generator for FRC"

Fixes the meta-description that shows on Discord embeds and elsewhere.

![image](https://user-images.githubusercontent.com/32416547/209860433-61006c63-1b04-41ad-bb0a-08cda423215d.png)
